### PR TITLE
add CI job to inspect CircleCI env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,14 @@ jobs:
     executor: basic
     steps:
       - my-checkout
-
+  on-forked-repo-only:
+    executor: basic
+    steps:
+      - checkout
+      - run: |
+          env | grep CIRCLE_
 workflows:
   main:
     jobs:
       - custom-checkout
+      - on-forked-repo-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - run: |
           # check out the org context!
-          # should print 'spoon'
+          # should print 'spoon', but masked
           printenv FORK
   custom-checkout:
     executor: basic


### PR DESCRIPTION
this is just a test PR on the forked repo itself.

Remember not to run `env` as part of your build output.
Secrets may get leaked.